### PR TITLE
Dockerize & Add Shim Scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+################################################################################
+#
+# Name:     slatinsky/DiscordChatExporter-incrementalBackup
+# Version:  0.0.2
+# License:  GPL
+# Sources:  github:Tyrrrz/DiscordChatExporter
+#
+# Usage:    You'll need to mount a volume containing config.json to /app/config
+#           The export directory goes to /app/export
+################################################################################
+FROM alpine:latest
+
+RUN apk update \
+    && apk add aspnetcore7-runtime bash npm
+
+RUN mkdir -p /app/config/ /app/dce/ /app/exports/ \
+    && wget https://github.com/Tyrrrz/DiscordChatExporter/releases/download/2.42.3/DiscordChatExporter.Cli.zip \
+    && unzip DiscordChatExporter.Cli.zip -d /app/dce/ \
+    && rm DiscordChatExporter.Cli.zip
+WORKDIR /app
+
+ADD . /app 
+
+RUN mv /app/scripts/run_backup.sh /app/run_backup.sh \
+    && chmod +x /app/run_backup.sh \
+    && mv /app/scripts/dotnet_shim.sh /app/dce/DiscordChatExporter.Cli \
+    && chmod +x /app/dce/DiscordChatExporter.Cli \
+    && ln -s /app/config/config.json /app/config.json
+
+RUN npm install
+
+CMD [ "bash", "/app/run_backup.sh" ]

--- a/scripts/dotnet_shim.sh
+++ b/scripts/dotnet_shim.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This is used to bridge the calls in main.js:94/97 to DCE on Linux
+$(which dotnet) /app/dce/DiscordChatExporter.Cli.dll $@

--- a/scripts/run_backup.sh
+++ b/scripts/run_backup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+$(which node) /app/main.js
+sleep 86400
+exec "$(readlink -f "$0")" # replace process with new copy of itself


### PR DESCRIPTION
Hello!

Per the reply in #1 I wanted to go ahead and open the PR. I'll explain why I did some of what I did, but this is my first time dockerizing anything, so I suppose be warned lol. This image is live right now in its current form but with the old overview [on dockerhub](https://hub.docker.com/r/zyradyl/discord-incremental) built for amd64.

First, this image is intended for use on a kubernetes cluster, so there's some weirdness from that. Specifically the use of `run_backup.sh`. A standard node entrypoint on main.js will work properly, however the container will gracefully stop itself when the job is completed. The cluster supervisor will then kick it back online, and thus an infinite cycle of restarting begins.

Second, there's a note in the script, but `dotnet_shim.sh` simply exists to bridge the call out to DCE from inside main.js to the correct linux command to run DCE.

Third, the image is constructed to work with directory/pvc mounts, as opposed to files. I believe with Docker you can just use `-v` to mount a single file to a specific path, but while that is possible through pure helm, the platform I use doesn't allow for it. As such, we assume that a directory containing `config.json` will be mounted at `/app/config` and thus create a symlink to that file. If the file isn't in the right place, the standard `main.js` error will be spit out.

Finally, re: using the DCE container itself, I considered that but when looking at the DCE dockerfile, right now they are using the official dotnet image which is a bit large, with a note to switch back to alpine once dotnet 8.0 is available on alpine's images. I had expected dotnet 7 on alpine to throw some sort of error, but I've used this image to back up 3 servers/240ish channels/120gb and haven't ran into any issues. My platform chokes on large images (I actually have to manually fetch DCEF when it updates) so making it as small as possible was important, thus I chose to build a custom image from alpine.

The Dockerfile was written after a quick skim of the dockerfile reference, and as such I expect something could probably be done better.

Let me know if you want any changes. ^.^