### PR TITLE
Channel-only mode implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ config.json will look like this:
         },
         {
             "tokenName": "mytoken",
+            "guildId": "channel",
+            "guildName": "guild-channel",
+            "channelId": "123456789012345678",
+            "enabled": true,
+            "throttleHours": 12
+        {
+            "tokenName": "mytoken",
             "guildId": "@me",
             "guildName": "mytoken-dms",
             "enabled": true,
@@ -90,6 +97,7 @@ You can also schedule `backup.exe` to run periodically using Windows Task Schedu
 - `guilds.tokenName` - your name for the discord token defined in `tokens.name`
 - `guilds.guildId` - the id of the guild you want to backup
 - `guilds.guildName` - name of the folder where the guild will be saved
+- `guilds.channelId` - the id of the channel you want to backup
 - `guilds.enabled` - if true, the guild will be backed up
 - `guilds.throttleHours` - minimum time between backups in hours. Set to 0 to backup every time the script is run.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example:
 - my discord token is `bXlzZWNyZXRkaXNjb3JkdG9rZW4=`
 - server id I want to back up is `123456789012345678`
 - I want to export dms (use `@me` as the guildId)
-  - Or I want to export a specific channel (use `channel` as guildId)
+  - Or I want to export a specific channel (use `channel` as the guildId)
     - channel id I want to back up is `876543210987654321`
 
 config.json will look like this:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Example:
 - my discord token is `bXlzZWNyZXRkaXNjb3JkdG9rZW4=`
 - server id I want to back up is `123456789012345678`
 - I want to export dms (use `@me` as server id)
+  - Or I want to export a specific channel (use `channel` as server id)
+    - channel id I want to back up is `876543210987654321`
 
 config.json will look like this:
 ```json
@@ -67,7 +69,7 @@ config.json will look like this:
             "tokenName": "mytoken",
             "guildId": "channel",
             "guildName": "guild-channel",
-            "channelId": "123456789012345678",
+            "channelId": "876543210987654321",
             "enabled": true,
             "throttleHours": 12
         },

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ config.json will look like this:
             "channelId": "123456789012345678",
             "enabled": true,
             "throttleHours": 12
+        },
         {
             "tokenName": "mytoken",
             "guildId": "@me",

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ dcef.exe
 Example:
 - my discord token is `bXlzZWNyZXRkaXNjb3JkdG9rZW4=`
 - server id I want to back up is `123456789012345678`
-- I want to export dms (use `@me` as server id)
-  - Or I want to export a specific channel (use `channel` as channel id)
+- I want to export dms (use `@me` as the guildId)
+  - Or I want to export a specific channel (use `channel` as guildId)
     - channel id I want to back up is `876543210987654321`
 
 config.json will look like this:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ config.json will look like this:
         {
             "tokenName": "mytoken",
             "guildId": "channel",
-            "guildName": "guild-channel",
+            "guildName": "mytoken-channel",
             "channelId": "876543210987654321",
             "enabled": true,
             "throttleHours": 12

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example:
 - my discord token is `bXlzZWNyZXRkaXNjb3JkdG9rZW4=`
 - server id I want to back up is `123456789012345678`
 - I want to export dms (use `@me` as server id)
-  - Or I want to export a specific channel (use `channel` as server id)
+  - Or I want to export a specific channel (use `channel` as channel id)
     - channel id I want to back up is `876543210987654321`
 
 config.json will look like this:

--- a/backup.py
+++ b/backup.py
@@ -138,6 +138,8 @@ class CommandRunner:
 
             # skip export if export was done recently (based on throttleHours from config)
             if last_export_timestamp is not None:
+                last_export_timestamp = last_export_timestamp.replace('Z', '+00:00')
+                nowTimestamp = nowTimestamp.replace('Z', '+00:00')
                 hoursSinceLastExport = (datetime.fromisoformat(nowTimestamp) - datetime.fromisoformat(last_export_timestamp)).total_seconds() / 3600
                 print(f'  Last export was {hoursSinceLastExport:.2f} hours ago')
                 if hoursSinceLastExport < guild['throttleHours']:

--- a/backup.py
+++ b/backup.py
@@ -100,6 +100,8 @@ class Timestamps:
 
         except FileNotFoundError:
             print('exports/metadata.json does not exist, starting from scratch')
+            with open(timestamp_path, 'w', encoding='utf-8') as f:
+                json.dump({'lastExportsTimestamps': {}}, f)
 
     def get_timestamp(self, guildId) -> str:
         return self._timestampsGuilds.get(guildId, None)

--- a/backup.py
+++ b/backup.py
@@ -36,6 +36,8 @@ class Config:
             guild['tokenValue'] = self._tokens[guild['tokenName']]
             if guild['guildId'] == '@me':
                 guild['type'] = 'exportdm'
+            elif guild['guildId'] == 'channel':
+                guild['type'] = 'export'
             else:
                 guild['type'] = 'exportguild'
 
@@ -67,7 +69,7 @@ class Config:
                 print(f'Guild must have "{required_field}" field defined - found empty value')
                 exit(1)
 
-        if guild['guildId'] != '@me' and not discord_snowflake.match(guild['guildId']):
+        if guild['guildId'] != '@me' and not 'channel' and not discord_snowflake.match(guild['guildId']):
             print(f'Guild field "guildId" must be a discord snowflake (must be a string of 17-19 digits or "@me" for DMs) - found {guild["guildId"]}')
             exit(1)
 
@@ -161,6 +163,8 @@ class CommandRunner:
                 command = f"{dce_path} exportguild --guild {guild['guildId']} --include-threads All {common_args} {custom_args}"
             elif guild['type'] == 'exportdm':
                 command = f"{dce_path} exportdm {common_args} {custom_args}"
+            elif guild['type'] == 'export':
+                command = f"{dce_path} export --channel {guild['channelId']} {common_args} {custom_args}"
             else:
                 print(f'  Unknown export type {guild["type"]}')
                 exit(1)


### PR DESCRIPTION
Closes #3

As the title says.
It's a basic implementation that I tried adding based on your code with the other modes.
As I know myself with Python there may or may not be issues, so there might be some checking needed.
Other than that, first initial testing worked just fine and it even displayed everything correctly on the wrapper, as I wanted.
![image](https://github.com/user-attachments/assets/810b069b-e826-4186-957a-57eedafe383c)

To make it work, just make sure that the guildId is set to channel, similar to how it's set to `@me` when you want to do DM only.
Additionally, add a channelID line and just type in the channel of your wish, it will look similar to this:

```json
        {
            "tokenName": "mytoken",
            "guildId": "channel",
            "guildName": "guild-channel",
            "channelId": "123456789012345678",
            "enabled": true,
            "throttleHours": 12
        }
```

Lastly, I kept encountering some issues with the metadata.json file before, and the last export check after.
Pretty much the metadata.json file never created itself, so it complained that there was no exports/metadata.json file, tho it did let me take Discord backups.
I went ahead and made it create a metadata.json file by default with the content `{ "lastExportsTimestamps": {} }`, which will get populated after the backup anyways, and then there was the last export check complaining that the string had a invalid isoformat, here the example: `ValueError: Invalid isoformat string: 2024-07-25T20:08:25.068968Z`.
So I changed it to replace the Z with +00:00 instead, trying not to change the main code itself too much.
After that, I successfully received the desired output. 
Example with throttle set to 24 hours:
```
  Last export was 0.06 hours ago
  Skipping export because throttleHours is set to 24 hours
```

Example with throttle set to 0 hours:
```
  Last export was 0.07 hours ago
  "dce/DiscordChatExporter.Cli" export --channel mychannelid --format Json --media --reuse-media --fuck-russia --markdown false --token mytoken --media-dir "mymediadir" --output "myoutput" --after "2024-07-25T20:08:10.432630+00:00"
  Resolving channel(s)...
  Exporting 1 channel(s)...
                                                                   
  mycategory / mychannel ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100%
                                                                   
  Successfully exported 0 channel(s).

  Failed to export 1 the following channel(s):
  mycategory / mychannel: Channel 'mychannel' of guild 'myserver' does not contain any messages within the specified period.

  Export failed.
    return code 1
  Error exporting myserver. Does dce/DiscordChatExporter.Cli exist? Maybe there are no new messages? Check the logs above 
  for more information.
```
Since I already made a backup, it successfully failed (lmao)